### PR TITLE
Add offline stub for openai

### DIFF
--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -1,0 +1,32 @@
+from .types.chat import (
+    ChatCompletion,
+    Choice,
+    ChatCompletionMessage,
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
+
+class _Completions:
+    def create(self, **kwargs):
+        raise NotImplementedError("OpenAI API is not available in this environment")
+
+
+class _Chat:
+    def __init__(self):
+        self.completions = _Completions()
+
+
+class OpenAI:
+    def __init__(self):
+        self.chat = _Chat()
+
+
+__all__ = [
+    "OpenAI",
+    "ChatCompletion",
+    "Choice",
+    "ChatCompletionMessage",
+    "ChatCompletionMessageToolCall",
+    "Function",
+]

--- a/openai/types/__init__.py
+++ b/openai/types/__init__.py
@@ -1,0 +1,15 @@
+from .chat import (
+    ChatCompletion,
+    Choice,
+    ChatCompletionMessage,
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
+__all__ = [
+    "ChatCompletion",
+    "Choice",
+    "ChatCompletionMessage",
+    "ChatCompletionMessageToolCall",
+    "Function",
+]

--- a/openai/types/chat/__init__.py
+++ b/openai/types/chat/__init__.py
@@ -1,0 +1,10 @@
+from .chat_completion import ChatCompletion, Choice, ChatCompletionMessage
+from .chat_completion_message_tool_call import ChatCompletionMessageToolCall, Function
+
+__all__ = [
+    "ChatCompletion",
+    "Choice",
+    "ChatCompletionMessage",
+    "ChatCompletionMessageToolCall",
+    "Function",
+]

--- a/openai/types/chat/chat_completion.py
+++ b/openai/types/chat/chat_completion.py
@@ -1,0 +1,52 @@
+import json
+
+from .chat_completion_message_tool_call import ChatCompletionMessageToolCall, Function
+
+
+class ChatCompletionMessage:
+    def __init__(self, role: str, content: str = "", tool_calls=None, function_call=None):
+        self.role = role
+        self.content = content
+        self.tool_calls = tool_calls
+        self.function_call = function_call
+
+    def model_dump_json(self):
+        def serialize_tool_call(tc: ChatCompletionMessageToolCall):
+            return {
+                "id": tc.id,
+                "type": tc.type,
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                },
+            }
+
+        tool_calls = (
+            [serialize_tool_call(tc) for tc in self.tool_calls]
+            if self.tool_calls
+            else None
+        )
+
+        return json.dumps(
+            {
+                "role": self.role,
+                "content": self.content,
+                "tool_calls": tool_calls,
+            }
+        )
+
+
+class Choice:
+    def __init__(self, message: ChatCompletionMessage, finish_reason: str = "stop", index: int = 0):
+        self.message = message
+        self.finish_reason = finish_reason
+        self.index = index
+
+
+class ChatCompletion:
+    def __init__(self, id: str, created: int, model: str, object: str, choices: list[Choice]):
+        self.id = id
+        self.created = created
+        self.model = model
+        self.object = object
+        self.choices = choices

--- a/openai/types/chat/chat_completion_message_tool_call.py
+++ b/openai/types/chat/chat_completion_message_tool_call.py
@@ -1,0 +1,11 @@
+class Function:
+    def __init__(self, name: str = "", arguments: str = ""):
+        self.name = name
+        self.arguments = arguments
+
+
+class ChatCompletionMessageToolCall:
+    def __init__(self, id: str = "", type: str = "", function: Function | None = None):
+        self.id = id
+        self.type = type
+        self.function = function or Function()


### PR DESCRIPTION
## Summary
- add a minimal `openai` package stub so the repository works without the real OpenAI SDK
- stub includes basic data structures used in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f10cd93c83259f1375379dd9226c