### PR TITLE
Add Jarvis example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Check out `/examples` for inspiration! Learn more about each one in its README.
 - [`airline`](examples/airline): A multi-agent setup for handling different customer service requests in an airline context.
 - [`support_bot`](examples/support_bot): A customer service bot which includes a user interface agent and a help center agent with several tools
 - [`personal_shopper`](examples/personal_shopper): A personal shopping agent that can help with making sales and refunding orders
+- [`jarvis`](examples/jarvis): Minimal example of an assistant named Jarvis using `run_demo_loop`
 
 # Documentation
 

--- a/examples/jarvis/README.md
+++ b/examples/jarvis/README.md
@@ -1,0 +1,11 @@
+# Jarvis
+
+This example demonstrates a minimal assistant agent named Jarvis. It uses Swarm's `run_demo_loop` to create an interactive command line session.
+
+## Setup
+
+Run the example with:
+
+```shell
+python3 run.py
+```

--- a/examples/jarvis/agents.py
+++ b/examples/jarvis/agents.py
@@ -1,0 +1,6 @@
+from swarm import Agent
+
+jarvis_agent = Agent(
+    name="Jarvis",
+    instructions="You are Jarvis, a helpful assistant.",
+)

--- a/examples/jarvis/run.py
+++ b/examples/jarvis/run.py
@@ -1,0 +1,5 @@
+from swarm.repl import run_demo_loop
+from agents import jarvis_agent
+
+if __name__ == "__main__":
+    run_demo_loop(jarvis_agent)


### PR DESCRIPTION
## Summary
- add a simple Jarvis agent example
- document the Jarvis example in the root README

## Testing
- `pytest -q` *(fails: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68720d67cfb4832583d394857243be63