### PR TITLE
Add Siri shortcut example

### DIFF
--- a/examples/jarvis_shortcut/README.md
+++ b/examples/jarvis_shortcut/README.md
@@ -1,0 +1,21 @@
+# Siri Shortcut to Start Jarvis
+
+This folder demonstrates how you can start a simple Jarvis script using Siri.
+
+The included files are:
+
+- `jarvis.py` – a minimal Python script that represents the Jarvis assistant.
+- `start_jarvis.applescript` – AppleScript used by the Siri Shortcut to run `jarvis.py`.
+
+## Creating the Shortcut
+
+1. Open the **Shortcuts** app on macOS.
+2. Create a new shortcut and name it **Jarvis**.
+3. Add the **Run AppleScript** action.
+4. Paste the contents of `start_jarvis.applescript` into the action.
+   Make sure to update the path to `jarvis.py` in the script.
+5. Save the shortcut.
+6. In the shortcut settings, assign the voice phrase `"Hey Siri, open Jarvis"`.
+
+Now, whenever you say *"Hey Siri, open Jarvis"*, macOS will execute the
+AppleScript, which in turn launches the Python script.

--- a/examples/jarvis_shortcut/jarvis.py
+++ b/examples/jarvis_shortcut/jarvis.py
@@ -1,0 +1,9 @@
+"""Minimal Jarvis assistant placeholder."""
+
+
+def main():
+    print("Jarvis is now running.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/jarvis_shortcut/start_jarvis.applescript
+++ b/examples/jarvis_shortcut/start_jarvis.applescript
@@ -1,0 +1,4 @@
+-- AppleScript to launch the Jarvis Python script
+-- Update the path below to the location of jarvis.py
+
+do shell script "python3 /path/to/examples/jarvis_shortcut/jarvis.py"


### PR DESCRIPTION
## Summary
- add example for triggering Jarvis with Siri
- show simple Jarvis python script and AppleScript snippet

## Testing
- `pytest -q` *(fails: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_687214abf93c8325bc83e86e32c64bbd