### PR TITLE
Add Jarvis code generation example

### DIFF
--- a/examples/basic/jarvis.py
+++ b/examples/basic/jarvis.py
@@ -1,0 +1,17 @@
+from swarm import Swarm, Agent
+
+client = Swarm()
+
+jarvis = Agent(
+    name="Jarvis",
+    instructions="""
+    You are Jarvis, a coding assistant. When the user asks for a program,
+    respond with the full Python script. Do not include any explanations.
+    """,
+)
+
+if __name__ == "__main__":
+    prompt = "Write a Python script that prints Hello, world!"
+    messages = [{"role": "user", "content": prompt}]
+    response = client.run(agent=jarvis, messages=messages)
+    print(response.messages[-1]["content"])


### PR DESCRIPTION
## Summary
- add `examples/basic/jarvis.py` demonstrating how to create a Jarvis agent that outputs Python scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_687235dd55a8832596ca62b5171eaed6