### PR TITLE
Add Jarvis example

### DIFF
--- a/examples/jarvis_agent/README.md
+++ b/examples/jarvis_agent/README.md
@@ -1,0 +1,12 @@
+# Jarvis agent
+
+This is a simple example demonstrating a single agent named Jarvis.
+The agent behaves like Tony Stark's helpful AI assistant.
+
+## Setup
+
+Run the example using:
+
+```shell
+python3 main.py
+```

--- a/examples/jarvis_agent/main.py
+++ b/examples/jarvis_agent/main.py
@@ -1,0 +1,10 @@
+from swarm import Agent
+from swarm.repl import run_demo_loop
+
+jarvis = Agent(
+    name="Jarvis",
+    instructions="You are Jarvis, Tony Stark's helpful AI assistant. Respond politely and helpfully to the user."
+)
+
+if __name__ == "__main__":
+    run_demo_loop(jarvis)


### PR DESCRIPTION
## Summary
- add a simple `Jarvis` agent example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6872432bb3708325b5f4a0560bb45af5