### PR TITLE
Fix comment role in mock client

### DIFF
--- a/tests/mock_client.py
+++ b/tests/mock_client.py
@@ -87,10 +87,10 @@ client.set_sequential_responses(
 first_response = client.chat.completions.create()
 print(
     first_response.choices[0].message
-)  # Outputs: role='agent' content='First response'
+)  # Outputs: role='assistant' content='First response'
 
 # This should return the second mock response
 second_response = client.chat.completions.create()
 print(
     second_response.choices[0].message
-)  # Outputs: role='agent' content='Second response'
+)  # Outputs: role='assistant' content='Second response'


### PR DESCRIPTION
## Summary
- update comments in `tests/mock_client.py` to show role='assistant'

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68802a2e62988325a4b97cc72d2b16da